### PR TITLE
Okno podglądu eksponatu z renderowaniem markdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ qt6_add_executable(${PROJECT_NAME}Tests
     include/itemList.h
     include/mainwindow.h
     include/photoitem.h
+    include/PreviewDialog.h
     include/fullscreenphotoviewer.h
     include/PacmanOverlay.h
     include/PacmanAnimationModel.h
@@ -116,6 +117,7 @@ qt6_add_executable(${PROJECT_NAME}Tests
     src/itemList.cpp
     src/mainwindow.cpp
     src/photoitem.cpp
+    src/PreviewDialog.cpp
     src/fullscreenphotoviewer.cpp
     src/PacmanOverlay.cpp
     src/PacmanAnimationModel.cpp

--- a/forms/PreviewDialog.ui
+++ b/forms/PreviewDialog.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PreviewDialog</class>
+ <widget class="QDialog" name="PreviewDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>720</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Podgląd eksponatu</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="nameLabel">
+     <property name="font">
+      <font>
+       <pointsize>18</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="metaLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="detailsLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="descriptionView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QTextBrowser { color: #111; background-color: #ffffff; padding: 8px; }</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <widget class="QPushButton" name="editButton">
+       <property name="text">
+        <string>Edytuj</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Zamknij</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/include/PreviewDialog.h
+++ b/include/PreviewDialog.h
@@ -1,0 +1,31 @@
+#ifndef PREVIEWDIALOG_H
+#define PREVIEWDIALOG_H
+
+#include <QDialog>
+#include <QSqlDatabase>
+#include <QString>
+
+namespace Ui
+{
+    class PreviewDialog;
+}
+
+class PreviewDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit PreviewDialog(QSqlDatabase db, const QString &recordId, QWidget *parent = nullptr);
+    ~PreviewDialog();
+
+signals:
+    void editRequested(const QString &recordId);
+
+private:
+    void loadRecord();
+
+    Ui::PreviewDialog *ui;
+    QSqlDatabase m_db;
+    QString m_recordId;
+};
+
+#endif // PREVIEWDIALOG_H

--- a/src/PreviewDialog.cpp
+++ b/src/PreviewDialog.cpp
@@ -1,0 +1,98 @@
+#include "PreviewDialog.h"
+#include "ui_PreviewDialog.h"
+
+#include <QPushButton>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QDebug>
+
+PreviewDialog::PreviewDialog(QSqlDatabase db, const QString &recordId, QWidget *parent)
+    : QDialog(parent), ui(new Ui::PreviewDialog), m_db(db), m_recordId(recordId)
+{
+    ui->setupUi(this);
+
+    connect(ui->closeButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(ui->editButton, &QPushButton::clicked, this, [this]()
+            {
+                emit editRequested(m_recordId);
+                accept();
+            });
+
+    loadRecord();
+}
+
+PreviewDialog::~PreviewDialog()
+{
+    delete ui;
+}
+
+void PreviewDialog::loadRecord()
+{
+    QSqlQuery q(m_db);
+    q.prepare(
+        "SELECT eksponaty.name, eksponaty.serial_number, eksponaty.part_number, "
+        "       eksponaty.revision, eksponaty.production_year, eksponaty.description, "
+        "       eksponaty.has_original_packaging, "
+        "       types.name AS type_name, vendors.name AS vendor_name, "
+        "       models.name AS model_name, statuses.name AS status_name, "
+        "       storage_places.name AS storage_name "
+        "FROM eksponaty "
+        "LEFT JOIN types ON eksponaty.type_id = types.id "
+        "LEFT JOIN vendors ON eksponaty.vendor_id = vendors.id "
+        "LEFT JOIN models ON eksponaty.model_id = models.id "
+        "LEFT JOIN statuses ON eksponaty.status_id = statuses.id "
+        "LEFT JOIN storage_places ON eksponaty.storage_place_id = storage_places.id "
+        "WHERE eksponaty.id = :id");
+    q.bindValue(":id", m_recordId);
+
+    if (!q.exec() || !q.next())
+    {
+        qWarning() << "PreviewDialog: nie udało się wczytać rekordu" << m_recordId
+                   << q.lastError().text();
+        ui->nameLabel->setText(tr("(brak rekordu)"));
+        return;
+    }
+
+    const QString name = q.value("name").toString();
+    const QString vendor = q.value("vendor_name").toString();
+    const QString model = q.value("model_name").toString();
+    const QString type = q.value("type_name").toString();
+    const int year = q.value("production_year").toInt();
+    const QString serial = q.value("serial_number").toString();
+    const QString partNum = q.value("part_number").toString();
+    const QString revision = q.value("revision").toString();
+    const QString status = q.value("status_name").toString();
+    const QString storage = q.value("storage_name").toString();
+    const bool origPack = q.value("has_original_packaging").toBool();
+    const QString description = q.value("description").toString();
+
+    ui->nameLabel->setText(name.isEmpty() ? tr("(bez nazwy)") : name);
+
+    QStringList metaParts;
+    if (!vendor.isEmpty())
+        metaParts << vendor;
+    if (!model.isEmpty())
+        metaParts << model;
+    if (!type.isEmpty())
+        metaParts << type;
+    if (year > 0)
+        metaParts << QString::number(year);
+    ui->metaLabel->setText(metaParts.join(QStringLiteral(" · ")));
+
+    QStringList detailParts;
+    if (!serial.isEmpty())
+        detailParts << tr("S/N: %1").arg(serial);
+    if (!partNum.isEmpty())
+        detailParts << tr("P/N: %1").arg(partNum);
+    if (!revision.isEmpty())
+        detailParts << tr("Rev: %1").arg(revision);
+    if (!status.isEmpty())
+        detailParts << tr("Status: %1").arg(status);
+    if (!storage.isEmpty())
+        detailParts << tr("Miejsce: %1").arg(storage);
+    if (origPack)
+        detailParts << tr("Oryginalne opakowanie");
+    ui->detailsLabel->setText(detailParts.join(QStringLiteral("  |  ")));
+
+    ui->descriptionView->setMarkdown(description);
+}

--- a/src/itemList.cpp
+++ b/src/itemList.cpp
@@ -35,6 +35,7 @@
 #include "ItemFilterProxyModel.h"
 #include "ItemRepository.h"
 #include "PhotoService.h"
+#include "PreviewDialog.h"
 #include "fullscreenphotoviewer.h"
 #include "mainwindow.h"
 #include "photoitem.h"
@@ -289,6 +290,22 @@ itemList::itemList(QWidget *parent)
             &QItemSelectionModel::selectionChanged,
             this,
             &itemList::onTableViewSelectionChanged);
+
+    // Podgląd eksponatu pod dwukrotnym kliknięciem
+    connect(ui->itemList_tableView, &QAbstractItemView::doubleClicked, this,
+            [this](const QModelIndex &proxyIdx)
+            {
+                if (!proxyIdx.isValid())
+                    return;
+                const QModelIndex srcIdx = m_proxyModel->mapToSource(proxyIdx);
+                const QString recordId = m_sourceModel->data(m_sourceModel->index(srcIdx.row(), 0)).toString();
+                if (recordId.isEmpty())
+                    return;
+                auto *preview = new PreviewDialog(QSqlDatabase::database("default_connection"), recordId, this);
+                preview->setAttribute(Qt::WA_DeleteOnClose);
+                connect(preview, &PreviewDialog::editRequested, this, &itemList::openRecordWindowForEdit);
+                preview->show();
+            });
 
     // Inicjalizacja timera utrzymującego połączenie
     m_keepAliveTimer = new QTimer(this);


### PR DESCRIPTION
## Co się zmienia
Dwukrotne kliknięcie na wierszu w liście eksponatów otwiera nowe okno **PreviewDialog** z czytelnym podglądem:

- Nagłówek: nazwa eksponatu (duży, pogrubiony)
- Meta: producent · model · typ · rok
- Detale: S/N, P/N, rewizja, status, miejsce, oryg. opakowanie
- Opis renderowany jako **markdown** (pogrubienia, nagłówki, listy) — bez widocznych gwiazdek
- Przyciski: "Edytuj" (otwiera istniejący formularz edycji) / "Zamknij"

Wzbogacenia AI zapisane w polu `description` (blok `**Opis muzealny**`, `**Kontekst historyczny**` itd.) są teraz czytelne od razu — bez konieczności wchodzenia w tryb edycji.

## Pliki
- `forms/PreviewDialog.ui` — nowy layout dialogu
- `include/PreviewDialog.h` + `src/PreviewDialog.cpp` — klasa dialogu (QDialog + QSqlQuery → JOIN na types/vendors/models/statuses/storage_places)
- `src/itemList.cpp` — connect `doubleClicked` na tableView + include
- `CMakeLists.txt` — PreviewDialog dodany do targetu Tests

## Plan testów
- [ ] 2× klik otwiera podgląd z poprawnymi danymi
- [ ] Markdown renderuje się (pogrubienia, nagłówki, listy)
- [ ] Tekst czarny na białym tle (explicit styleSheet, by stylesheet skóry nie nadpisał)
- [ ] Przycisk "Edytuj" otwiera formularz edycji tego samego rekordu
- [ ] "Zamknij" zamyka dialog
- [ ] Build czysty, 29/29 testów PASS