### PR TITLE
chore: audit lint cleanup (API-5 + HDR-3 + DEP-7)

### DIFF
--- a/docs/audit-2026-04-26-desktop.md
+++ b/docs/audit-2026-04-26-desktop.md
@@ -1,0 +1,82 @@
+# Audit Inwentaryzacja desktop v1.3.0 — 2026-04-26
+
+**Scope:** `src/*.cpp` (23 files) + `include/*.h` (21 files) = **~10,800 LoC**
+**Tool:** `qt-cpp-review` skill (qt-development-skills plugin), Phase 1 lint + spot-check
+**Branch:** dev (commit `dcffd57` "Bump wersji 1.2.11 → 1.3.0")
+
+## TL;DR
+
+**Codebase jest mature i czysty.** 48 lint hits / 10.8K LoC = **0.45% noise**. Mobile (Inwentaryzacja-Mobile) miał 25% (122 hits / 470 LoC) — desktop ma **55× lepszy lint score per LoC**.
+
+**Nowy kod z PR #15 (PreviewDialog markdown) jest CZYSTY** — 0 hits w `PreviewDialog.h/cpp`. Przeszło code review.
+
+## Lint output histogram
+
+| Reguła | Hits | Realne? | Action |
+|---|---|---|---|
+| HDR-3 — `std::min/max` bez parens (Windows macro safety) | 11 | TAK | Mechaniczny fix `(std::min)(a, b)` |
+| ERR-6 — `arg()` mismatch | 9 | **FALSE POSITIVE** | Lint nie rozpoznaje `.arg(s1, s2)` overload — wszystkie 9 są poprawne |
+| DEP-10 — `.count()/.length()` → `.size()` | 9 | Cosmetic | Skip — `.length()` na QString jest community convention |
+| DEP-7 — `qMin/qMax` → `std::min/max/clamp` | 6 | Cosmetic | Skip — qXxx są w pełni supported w Qt6 |
+| API-5 — get-prefix na getter | 6 | TAK (nowy kod Pacman) | Rename `getX()` → `x()` |
+| TMO-1 — `int xMs` → `std::chrono` | 4 | **FALSE POSITIVE** | Pola `Config` struct, nie API parametry |
+| DEP-11 — `currentDateTime()` → `currentDateTimeUtc()` | 1 | **TAK (perf)** | 100× faster, DST-stable — ale itemList:950 to log timestamp, low priority |
+| PAT-12 — non-const range-for | 1 | False positive (świadoma mutacja) | Skip |
+| DEP-13 — `QChar` jako object | 1 | Cosmetic | Skip |
+
+## Skupiska (per plik)
+
+| Plik | Hits | Charakter |
+|---|---|---|
+| `PacmanOverlay.h/cpp` | 18 | Świeży kod (loader animation), zbiera get-prefix + HDR-3 + DEP-10 |
+| `PacmanAnimationModel.h/cpp` | 9 | jw. |
+| `DatabaseSchemaUtils.cpp` | 6 | Wszystkie 6 = ERR-6 false positive |
+| `itemList.cpp` | 5 | Mature plik (1100+ LoC), DEP-7/DEP-11/PAT-12 |
+| `mainwindow.cpp` | 4 | Cosmetic |
+| `PreviewDialog.h/cpp` (PR #15, NEW) | **0** | **Czysty** |
+| Pozostałe | 6 | Pojedyncze |
+
+## Czego BRAKUJE (positive signal vs mobile)
+
+W mobile audit znaleźliśmy:
+- C-D01 race w singletonie JNI ⚠ CRITICAL
+- C-D02 OOM w `readAll().toBase64()` ⚠ HIGH
+- L-01 brak SSL handler na QNAM
+- L-04 brak JSON validation
+- C-D07 path traversal vulnerability
+- Q-05 cross-page leak w QML singleton
+
+W desktop **żaden z tych wzorców nie wystąpił:**
+- Brak threading hazards (aplikacja głównie main-thread)
+- Brak SSL/network attack surface (lokalna baza SQLite/MySQL)
+- Brak path traversal (file ops przez Qt File dialogs)
+- Brak Q_ASSERT side effects
+- Brak ownership leaks
+- Brak get-prefix w starym kodzie (tylko w nowym Pacman)
+
+## Realne fixy (zrobione w 1 PR)
+
+- **API-5:** 6 Pacman getter rename + getPacmanDelayMs (DatabaseConfigDialog) — `getX()` → `x()`
+- **HDR-3:** 11 `std::min/max/numeric_limits` w nawiasach (Windows MSVC bez NOMINMAX)
+- **DEP-7:** 2 `qBound` → `std::clamp` w PacmanOverlay.h (i tak ruszamy plik)
+
+Pominięte świadomie:
+- ERR-6 (false positive `.arg(s1, s2)` overload)
+- TMO-1 (false positive — pola Config struct)
+- DEP-7 qMin/qMax w mature plikach (Qt idiom, full supported)
+- DEP-10 `.length()` (community convention)
+- DEP-13 QChar
+- PAT-12 (świadoma mutacja w itemList)
+- DEP-11 currentDateTime (log timestamp, low priority — 1 plik, separate PR jeśli warto)
+
+## Phase 2 deep agents — pominięte świadomie
+
+Koszt vs zysk dla mature CRUD app niekorzystny. Jeśli kiedyś chcielibyśmy:
+- **Selektywnie** Agent 2 (Ownership) + Agent 5 (Error Handling) na `ItemRepository.cpp` (najbardziej skomplikowana klasa, CRUD core)
+- Skip: Model Contracts (nie używamy QAbstractItemModel ekstensywnie), Threading (głównie main-thread), API/C++ correctness (mature codebase), Performance (nie skarżymy się na slow)
+
+## Następne sesje (do rozważenia)
+
+- Sync z mobile — porównanie schematu MariaDB między desktop ItemRepository a backend FastAPI Pydantic models
+- Tests coverage — `tests/repository_tests.cpp` to tylko 1 plik na ~10K LoC produkcyjnego kodu
+- DEP-11 `currentDateTimeUtc` w itemList:950 jeśli ktoś analizuje logs i widzi DST anomalie

--- a/include/DatabaseConfigDialog.h
+++ b/include/DatabaseConfigDialog.h
@@ -152,7 +152,7 @@ public:
      * @section MethodOverview
      * Zwraca aktualną wartość statycznej zmiennej opóźnienia Pac-Mana.
      */
-    static int getPacmanDelayMs();
+    static int pacmanDelayMs();  // API-5
 
 public slots:
     /**

--- a/include/PacmanOverlay.h
+++ b/include/PacmanOverlay.h
@@ -3,6 +3,8 @@
 #include <QElapsedTimer>
 #include <QPixmap>
 
+#include <algorithm>  // std::clamp
+
 #include "PacmanAnimationModel.h"
 
 class PacmanOverlay : public QWidget
@@ -14,12 +16,12 @@ public:
     void start(int durationMs = 5000);
 
     static void setPacmanSpeedPx(double px) { s_pacmanSpeedPx = px; }
-    static double getPacmanSpeedPx() { return s_pacmanSpeedPx; }
+    static double pacmanSpeedPx() { return s_pacmanSpeedPx; }  // API-5
     static void setEatCharIntervalMs(int ms) { s_eatCharIntervalMs = ms; }
-    static int getEatCharIntervalMs() { return s_eatCharIntervalMs; }
+    static int eatCharIntervalMs() { return s_eatCharIntervalMs; }  // API-5
 
     void setCollisionHideMs(int ms) { m_collisionHideMs = ms; }
-    int getCollisionHideMs() const { return m_collisionHideMs; }
+    int collisionHideMs() const { return m_collisionHideMs; }  // API-5
 
     // Metody do obsługi specjalnych dat aktywacji
     static void setBirthdayActivation(int day, int month)
@@ -33,14 +35,14 @@ public:
     static void enablePacManReleaseActivation(bool enable) { s_enablePacManReleaseActivation = enable; }
     static bool isRandomActivationEnabled() { return s_enableRandomActivation; }
     static void enableRandomActivation(bool enable) { s_enableRandomActivation = enable; }
-    static int getRandomActivationChance() { return s_randomActivationChance; }
-    static void setRandomActivationChance(int chance) { s_randomActivationChance = qBound(0, chance, 100); }
+    static int randomActivationChance() { return s_randomActivationChance; }  // API-5
+    static void setRandomActivationChance(int chance) { s_randomActivationChance = std::clamp(chance, 0, 100); }  // DEP-7
 
     // Metody do obsługi aktywacji opartej na dokładnej długości tekstu
     static bool isCapacityActivationEnabled() { return s_enableCapacityActivation; }
     static void enableCapacityActivation(bool enable) { s_enableCapacityActivation = enable; }
-    static int getCapacityCharCount() { return s_capacityCharCount; }
-    static void setCapacityCharCount(int count) { s_capacityCharCount = qBound(1, count, 1000); }
+    static int capacityCharCount() { return s_capacityCharCount; }  // API-5
+    static void setCapacityCharCount(int count) { s_capacityCharCount = std::clamp(count, 1, 1000); }  // DEP-7
 
 signals:
     void activated();

--- a/src/DatabaseConfigDialog.cpp
+++ b/src/DatabaseConfigDialog.cpp
@@ -163,7 +163,7 @@ DatabaseConfigDialog::DatabaseConfigDialog(QWidget *parent)
     // Pacman easter egg (usuń lub ogranicz do pól tekstowych)
     QTimer *pacmanTimer = new QTimer(this);
     pacmanTimer->setSingleShot(true);
-    pacmanTimer->setInterval(getPacmanDelayMs());
+    pacmanTimer->setInterval(pacmanDelayMs());
     connect(pacmanTimer, &QTimer::timeout, this, [this]() {
         QWidget *focus = QApplication::focusWidget();
         // Ogranicz do QLineEdit/QTextEdit/QPlainTextEdit
@@ -305,7 +305,7 @@ int DatabaseConfigDialog::mysqlPort() const
 // --- Pacman easter egg timer param ---
 int DatabaseConfigDialog::g_pacmanDelayMs = 4000; // domyślnie 15*60*1000
 void DatabaseConfigDialog::setPacmanDelayMs(int ms) { g_pacmanDelayMs = ms; }
-int DatabaseConfigDialog::getPacmanDelayMs() { return g_pacmanDelayMs; }
+int DatabaseConfigDialog::pacmanDelayMs() { return g_pacmanDelayMs; }
 // ---
 
 /**

--- a/src/PacmanAnimationModel.cpp
+++ b/src/PacmanAnimationModel.cpp
@@ -13,16 +13,16 @@ void PacmanAnimationModel::start(int textWidth, int approximateCharWidth, int ch
 
     m_state = State::Delay;
     m_currentTextWidth = textWidth;
-    m_remainingChars = std::max(0, charCount);
+    m_remainingChars = (std::max)(0, charCount);
     m_pacmanX = static_cast<double>(textWidth);
     m_targetPacmanX = static_cast<double>(textWidth);
 
-    const int emptySpaceWidth = std::max(approximateCharWidth, 1) * std::max(charCount, 1);
+    const int emptySpaceWidth = (std::max)(approximateCharWidth, 1) * (std::max)(charCount, 1);
     const double ghostStartX = static_cast<double>(textWidth + emptySpaceWidth);
     m_ghostX = ghostStartX;
 
-    const int effectiveChaseTimeMs = std::max(1, m_remainingChars * m_config.eatCharIntervalMs - m_config.ghostDelayMs);
-    const double ghostDistance = std::max(0.0, ghostStartX);
+    const int effectiveChaseTimeMs = (std::max)(1, m_remainingChars * m_config.eatCharIntervalMs - m_config.ghostDelayMs);
+    const double ghostDistance = (std::max)(0.0, ghostStartX);
     m_config.ghostSpeedPxPerSecond = (ghostDistance * 1000.0) / effectiveChaseTimeMs;
 }
 
@@ -75,7 +75,7 @@ void PacmanAnimationModel::advance(int deltaMs)
 
 void PacmanAnimationModel::setCurrentTextWidth(int textWidth)
 {
-    m_currentTextWidth = std::max(0, textWidth);
+    m_currentTextWidth = (std::max)(0, textWidth);
     m_targetPacmanX = static_cast<double>(m_currentTextWidth);
 }
 
@@ -209,9 +209,9 @@ void PacmanAnimationModel::updatePacmanPosition(int deltaMs)
 {
     const double step = m_config.pacmanSpeedPxPerSecond * (static_cast<double>(deltaMs) / 1000.0);
     if (m_pacmanX > m_targetPacmanX)
-        m_pacmanX = std::max(m_targetPacmanX, m_pacmanX - step);
+        m_pacmanX = (std::max)(m_targetPacmanX, m_pacmanX - step);
     else if (m_pacmanX < m_targetPacmanX)
-        m_pacmanX = std::min(m_targetPacmanX, m_pacmanX + step);
+        m_pacmanX = (std::min)(m_targetPacmanX, m_pacmanX + step);
 }
 
 void PacmanAnimationModel::updateGhostPosition(int deltaMs)
@@ -230,7 +230,7 @@ void PacmanAnimationModel::updateGhostPosition(int deltaMs)
         return;
     }
 
-    m_ghostX = std::max(0.0, nextGhostX);
+    m_ghostX = (std::max)(0.0, nextGhostX);
 }
 
 void PacmanAnimationModel::enterFinished()

--- a/src/PacmanOverlay.cpp
+++ b/src/PacmanOverlay.cpp
@@ -191,9 +191,9 @@ void PacmanOverlay::paintEvent(QPaintEvent *)
     painter.setRenderHint(QPainter::Antialiasing);
 
     const int y = (height() - kSpriteSizePx) / 2;
-    drawPacman(painter, std::max(static_cast<int>(std::round(m_pacmanX)), 0), y, kSpriteSizePx);
+    drawPacman(painter, (std::max)(static_cast<int>(std::round(m_pacmanX)), 0), y, kSpriteSizePx);
     if (m_showGhost)
-        drawGhost(painter, std::max(static_cast<int>(std::round(m_ghostX)), 0), y, kSpriteSizePx);
+        drawGhost(painter, (std::max)(static_cast<int>(std::round(m_ghostX)), 0), y, kSpriteSizePx);
 
     raise();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -123,7 +123,7 @@ MainWindow::MainWindow(QWidget *parent)
     loadComboBoxData("models", ui->New_item_model);
     loadComboBoxData("statuses", ui->New_item_status);
     loadComboBoxData("storage_places", ui->New_item_storagePlace);
-    ui->New_item_value->setValidator(new QIntValidator(0, std::numeric_limits<int>::max(), this));
+    ui->New_item_value->setValidator(new QIntValidator(0, (std::numeric_limits<int>::max)(), this));  // HDR-3 Windows macro safety
     ui->New_item_ProductionDate->setDisplayFormat(QStringLiteral("yyyy"));
 
     // Podpinanie sygnałów i slotów przycisków


### PR DESCRIPTION
## Cel
Cleanup po audycie qt-cpp-review na v1.3.0. Pełny raport: `docs/audit-2026-04-26-desktop.md`.

## TL;DR
**Codebase mature i czysty** — 0.45% lint noise per LoC. **PreviewDialog z PR #15 jest 0 hits** (nowy kod przeszedł review). 17 realnych fixów z 48 raw hits.

## Zmiany

| Reguła | Plik | Co |
|---|---|---|
| **API-5** Qt convention `get`-prefix | PacmanOverlay.h, DatabaseConfigDialog.h+cpp | 6 getterów bez `get`: `pacmanSpeedPx()`, `eatCharIntervalMs()`, `collisionHideMs()`, `randomActivationChance()`, `capacityCharCount()`, `pacmanDelayMs()`. Wewnętrzne API Pacman — zerowa szansa zewnętrznego callsite. |
| **HDR-3** Windows macro safety | PacmanAnimationModel.cpp, PacmanOverlay.cpp, mainwindow.cpp | 11× `std::min(a, b)` → `(std::min)(a, b)` + `numeric_limits<int>::max()` → `(numeric_limits<int>::max)()`. Buduje czysto na MSVC bez `NOMINMAX` define. |
| **DEP-7** qBound → std::clamp | PacmanOverlay.h | 2× `qBound(0, x, 100)` → `std::clamp(x, 0, 100)` + `#include <algorithm>`. Tylko miejsca które i tak ruszamy. |

## Świadomie pominięte (z uzasadnieniem w raporcie)

| Reguła | Hits | Powód |
|---|---|---|
| ERR-6 | 9 | False positive — lint nie ogarnia `.arg(QString, QString)` overload |
| TMO-1 | 4 | False positive — `int xMs` to pola `Config` struct, nie API parametry |
| DEP-7 qMin/qMax w itemList/mainwindow | 4 | Qt6 supported, idiom, mature plik |
| DEP-10 `.length()` | 9 | Community convention dla QString |
| DEP-13 QChar | 1 | Cosmetic |
| PAT-12 | 1 | Świadoma mutacja w itemList |
| DEP-11 currentDateTimeUtc | 1 | Log timestamp, low priority — separate PR jeśli warto |

## Test plan
- [x] CMake configure clean
- [x] Build clean (55/55) — Qt 6.8.2, Linux Release Ninja
- [x] Tests: 1/1 pass (`repository_tests`)
- [ ] Manual: uruchom apkę i potwierdź że Pacman easter egg dalej działa (zmiana getterów Pacman)
- [ ] CI: GitHub Actions Windows build clean (HDR-3 fix dotyczy MSVC)

## Phase 2 deep agents
**Pominięte świadomie** — koszt vs zysk dla mature CRUD app niekorzystny. Jeśli kiedyś chcielibyśmy: selektywnie Agent 2 (Ownership) + Agent 5 (Error Handling) na `ItemRepository.cpp` (najbardziej skomplikowana klasa, CRUD core).