### PR TITLE
docs: dodaj Claude do listy AI-asystentów (credits, bez release)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .continue/
+.claude/
+build/
 build_inwentaryzacja/
 build_qt_sql_drivers/
 deploy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ Format opiera się na [Keep a Changelog](https://keepachangelog.com/pl/1.0.0/), 
   - `database_example_record.sql`: Przykładowe rekordy do testowania bazy.
 - **Dokumentacja**: Plik `README.md` opisujący:
   - Cel projektu (inwentaryzacja retro komputerów).
-  - Proces tworzenia z użyciem AI (ChatGPT, GROK, DeepSeek).
+  - Proces tworzenia z użyciem AI (Claude, ChatGPT, GROK, DeepSeek).
   - Wymagania (Qt 6.8.1, SQLite3) i instrukcje instalacji.
 - **Gitignore**: Plik `.gitignore` ignorujący pliki tymczasowe (`build/`, `*.db`, `*.DS_Store` itp.).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Witaj w projekcie **Inwentaryzacja**! To narzędzie stworzone z myślą o maniak
 
 ## Po co to wszystko?
 
-Chciałem mieć soft skrojony pod moje potrzeby – prosty, ale funkcjonalny, do zarządzania kolekcją retro komputerów. Sam jestem „marnym programistą” (doba ma tylko 24 godziny!), więc pisanie tego od zera zajęłoby mi pewnie z 5 lat. Zamiast tego postawiłem na eksperyment: tworzę ten program z pomocą AI – **ChatGPT** i **GROK**. 
+Chciałem mieć soft skrojony pod moje potrzeby – prosty, ale funkcjonalny, do zarządzania kolekcją retro komputerów. Sam jestem „marnym programistą” (doba ma tylko 24 godziny!), więc pisanie tego od zera zajęłoby mi pewnie z 5 lat. Zamiast tego postawiłem na eksperyment: tworzę ten program z pomocą AI – **Claude**, **ChatGPT** i **GROK**. 
 
 Jedyna rzecz, którą zrobiłem sam, to początkowe GUI, ale i tak AI zrobiło poprawioną wersję. 
 
@@ -84,7 +84,7 @@ Pisz na do mnie, albo dołącz do repozytorium. Razem stworzymy soft, który usz
 
 ## Dlaczego AI?
 
-Bo to przyszłość, a ja lubię testować granice. ChatGPT i GROK piszą kod szybciej, niż ja nadążam sprawdzać. To jak mieć zespół programistów w kieszeni – tylko czasem trzeba ich poprawić. 😄 Eksperyment trwa, a efekty? Sami oceńcie – Inwentaryzacja działa i ma się dobrze!
+Bo to przyszłość, a ja lubię testować granice. Claude, ChatGPT i GROK piszą kod szybciej, niż ja nadążam sprawdzać. To jak mieć zespół programistów w kieszeni – tylko czasem trzeba ich poprawić. 😄 Eksperyment trwa, a efekty? Sami oceńcie – Inwentaryzacja działa i ma się dobrze!
 
 ## Plany na przyszłość
 
@@ -95,7 +95,7 @@ Bo to przyszłość, a ja lubię testować granice. ChatGPT i GROK piszą kod sz
 
 ## Podziękowania
 
-Specjalne wirtualne ukłony dla **ChatGPT** i **GROK** – bez nich ten kod by nie powstał!
+Specjalne wirtualne ukłony dla **Claude**, **ChatGPT** i **GROK** – bez nich ten kod by nie powstał!
 
 ---
 
@@ -117,4 +117,4 @@ Fonty TTF: C64 - Copyright Filip Blazek 2008, ZX Spectrum: Copyright (c) 2016, J
 
 Aby być w zgodzie z licencjami, upewnij się, że przy dystrybucji aplikacji zapewniasz dostęp do kodu źródłowego bibliotek LGPL/GPL.
 Podziękowania
-Wielkie dzięki dla ChatGPT i Grok za napisanie kodu, oraz dla Qt, SQLite, MySQL i MinGW za napędzanie tego projektu! 😎
+Wielkie dzięki dla Claude, ChatGPT i Grok za napisanie kodu, oraz dla Qt, SQLite, MySQL i MinGW za napędzanie tego projektu! 😎

--- a/documentation/DatabaseConfigDialog_cpp.md
+++ b/documentation/DatabaseConfigDialog_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: DatabaseConfigDialog.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `DatabaseConfigDialog.cpp` zawiera implementację metod klasy `DatabaseConfigDialog`, odpowiedzialnej za konfigurację parametrów połączenia z bazą danych (SQLite lub MySQL) oraz wybór skórki graficznej aplikacji (Amiga, Atari 8bit, ZX Spectrum, Standard). Implementacja obejmuje ładowanie stylów QSS, czcionek, zapis ustawień w `QSettings` oraz obsługę dynamicznego wyboru pliku SQLite z możliwością tworzenia nowego pliku `.db`.

--- a/documentation/DatabaseConfigDialog_h.md
+++ b/documentation/DatabaseConfigDialog_h.md
@@ -4,7 +4,7 @@
 - **Plik**: DatabaseConfigDialog.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `DatabaseConfigDialog.h` definiuje klasę `DatabaseConfigDialog`, która reprezentuje okno dialogowe do konfiguracji parametrów połączenia z bazą danych (SQLite lub MySQL) oraz wyboru skórki graficznej aplikacji (Amiga, Atari 8bit, ZX Spectrum, Standard). Klasa dostarcza metody dostępowe do parametrów bazy danych, obsługuje dynamiczną zmianę stylów i czcionek oraz zapisuje ustawienia w `QSettings` dla trwałości między sesjami aplikacji.

--- a/documentation/ItemFilterProxyModel_cpp.md
+++ b/documentation/ItemFilterProxyModel_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: ItemFilterProxyModel.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `ItemFilterProxyModel.cpp` zawiera implementację metod klasy `ItemFilterProxyModel`, która umożliwia dynamiczne filtrowanie listy eksponatów w aplikacji inwentaryzacyjnej na podstawie atrybutów takich jak typ, producent, model, status i miejsce przechowywania. Klasa korzysta z mechanizmu `QSortFilterProxyModel`, zapewniając filtrowanie wierszy modelu źródłowego (np. `QSqlRelationalTableModel`) z ignorowaniem wielkości liter.

--- a/documentation/ItemFilterProxyModel_h.md
+++ b/documentation/ItemFilterProxyModel_h.md
@@ -4,7 +4,7 @@
 - **Plik**: ItemFilterProxyModel.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `ItemFilterProxyModel.h` definiuje klasę `ItemFilterProxyModel`, która dziedziczy po `QSortFilterProxyModel` i służy do dynamicznego filtrowania listy eksponatów w aplikacji inwentaryzacyjnej. Klasa umożliwia ustawienie filtrów dla atrybutów eksponatu, takich jak typ, producent, model, status i miejsce przechowywania, oraz kontroluje, które wiersze modelu źródłowego są wyświetlane w widoku na podstawie zadanych kryteriów.

--- a/documentation/fullscreenphotoviewer_cpp.md
+++ b/documentation/fullscreenphotoviewer_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: fullscreenphotoviewer.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `fullscreenphotoviewer.cpp` jest pusty, ponieważ cała implementacja klas `ZoomableGraphicsView` i `FullScreenPhotoViewer` znajduje się w pliku nagłówkowym `fullscreenphotoviewer.h`, gdzie metody są zdefiniowane inline. Plik istnieje dla kompletności struktury projektu i zgodności z konwencją oddzielania deklaracji od implementacji w projektach Qt.

--- a/documentation/fullscreenphotoviewer_h.md
+++ b/documentation/fullscreenphotoviewer_h.md
@@ -4,7 +4,7 @@
 - **Plik**: fullscreenphotoviewer.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `fullscreenphotoviewer.h` definiuje dwie klasy: `ZoomableGraphicsView` oraz `FullScreenPhotoViewer`, używane w aplikacji inwentaryzacyjnej do pełnoekranowego podglądu zdjęć eksponatów. `ZoomableGraphicsView` umożliwia powiększanie i przesuwanie obrazu za pomocą kółka myszy i przeciągania, natomiast `FullScreenPhotoViewer` tworzy bezramkowe, modalne okno pełnoekranowe z możliwością zamknięcia klawiszem Escape.

--- a/documentation/itemList_cpp.md
+++ b/documentation/itemList_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: itemList.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `itemList.cpp` zawiera implementację metod klasy `itemList`, która zarządza listą eksponatów w aplikacji inwentaryzacyjnej. Obsługuje połączenie z bazą danych MySQL, filtrowanie kaskadowe, wyświetlanie miniatur zdjęć, podgląd pełnoekranowy oraz operacje CRUD (dodawanie, edycja, usuwanie, klonowanie rekordów). Skórka graficzna i czcionki są zarządzane przez klasę `DatabaseConfigDialog`.

--- a/documentation/itemList_h.md
+++ b/documentation/itemList_h.md
@@ -4,7 +4,7 @@
 - **Plik**: itemList.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `itemList.h` definiuje klasę `itemList`, która jest głównym widgetem aplikacji inwentaryzacyjnej, odpowiedzialnym za wyświetlanie i zarządzanie listą eksponatów. Klasa obsługuje filtrowanie kaskadowe, operacje CRUD (Create, Read, Update, Delete), wyświetlanie miniatur zdjęć, podgląd pełnoekranowy oraz interakcje użytkownika. Skórka graficzna i czcionki są zarządzane przez klasę `DatabaseConfigDialog`.

--- a/documentation/main.md
+++ b/documentation/main.md
@@ -4,7 +4,7 @@
 - **Plik**: main.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `main.cpp` jest głównym punktem wejścia aplikacji inwentaryzacyjnej opartej na bibliotece Qt. Odpowiada za inicjalizację aplikacji, ustawienie jej podstawowych właściwości (nazwa, wersja, ikona), ładowanie tłumaczeń językowych, wyświetlanie okna konfiguracji bazy danych oraz nawiązywanie połączenia z wybraną bazą danych (SQLite lub MySQL). Po poprawnym skonfigurowaniu środowiska uruchamia główne okno aplikacji reprezentowane przez klasę `itemList`.

--- a/documentation/mainwindow_cpp.md
+++ b/documentation/mainwindow_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: mainwindow.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `mainwindow.cpp` zawiera implementację metod klasy `MainWindow`, odpowiedzialnej za formularz do dodawania, edycji i klonowania eksponatów w aplikacji inwentaryzacyjnej. Klasa obsługuje ładowanie danych do combo boxów, zarządzanie zdjęciami (w bazie i buforze), zapisywanie rekordów w bazie danych MySQL oraz otwieranie dialogów słownikowych. Implementacja obejmuje również automatyczne dodawanie nowych wartości do słowników po ich wpisaniu w combo boxach.

--- a/documentation/mainwindow_h.md
+++ b/documentation/mainwindow_h.md
@@ -4,7 +4,7 @@
 - **Plik**: mainwindow.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `mainwindow.h` definiuje klasę `MainWindow`, która reprezentuje główne okno formularza do dodawania, edycji i klonowania eksponatów w aplikacji inwentaryzacyjnej. Klasa obsługuje ładowanie danych do combo boxów, zarządzanie zdjęciami (w bazie i buforze), tryby edycji/klonowania oraz komunikację z bazą danych MySQL. Emituje sygnał `recordSaved` po zapisaniu rekordu i zawiera sloty do obsługi akcji użytkownika, takich jak zapis, anulowanie czy dodawanie zdjęć.

--- a/documentation/models_cpp.md
+++ b/documentation/models_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: models.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `models.cpp` zawiera implementację metod klasy `models`, odpowiedzialnej za zarządzanie modelami eksponatów w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie modeli w tabeli `models` w bazie danych MySQL, współpracując z interfejsem użytkownika (`QListView`, `QLineEdit`) oraz klasą `MainWindow` w celu odświeżania combo boxów. Obsługuje powiązanie modeli z producentami poprzez `vendorId` (QString).

--- a/documentation/models_h.md
+++ b/documentation/models_h.md
@@ -4,7 +4,7 @@
 - **Plik**: models.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `models.h` definiuje klasę `models`, która reprezentuje okno dialogowe do zarządzania modelami eksponatów w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie modeli w tabeli `models` w bazie danych, a także odświeżanie listy modeli w combo boxie głównego okna (`MainWindow`). Obsługuje identyfikator producenta (`vendorId`) jako `QString`, co pozwala powiązać modele z konkretnymi producentami.

--- a/documentation/photoitem_cpp.md
+++ b/documentation/photoitem_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: photoitem.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `photoitem.cpp` zawiera implementację metod klasy `PhotoItem`, która reprezentuje interaktywną miniaturę zdjęcia w scenie graficznej Qt (`QGraphicsView`) w aplikacji inwentaryzacyjnej. Klasa rozszerza `QGraphicsPixmapItem` o obsługę zdarzeń myszy (kliknięcia, podwójne kliknięcia) i hover (najechanie, opuszczenie), a także wizualne zaznaczanie za pomocą czerwonej ramki. Dzięki dziedziczeniu po `QObject`, umożliwia emisję sygnałów (`clicked`, `doubleClicked`, `hovered`, `unhovered`) do integracji z logiką aplikacji, np. z klasą `MainWindow` dla wyboru lub podglądu zdjęć eksponatów.

--- a/documentation/photoitem_h.md
+++ b/documentation/photoitem_h.md
@@ -4,7 +4,7 @@
 - **Plik**: photoitem.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `photoitem.h` definiuje klasę `PhotoItem`, która reprezentuje interaktywny element graficzny (miniaturę zdjęcia) w scenie graficznej Qt (używany w `QGraphicsView`). Klasa rozszerza `QGraphicsPixmapItem` o obsługę zdarzeń myszy (kliknięcia, podwójne kliknięcia) i hover (najechanie, opuszczenie kursora), a także wizualne zaznaczanie za pomocą czerwonej ramki. Dzięki dziedziczeniu po `QObject`, umożliwia emisję sygnałów (`clicked`, `doubleClicked`, `hovered`, `unhovered`), co pozwala na integrację z logiką aplikacji, np. z klasą `MainWindow` w aplikacji inwentaryzacyjnej.

--- a/documentation/status_cpp.md
+++ b/documentation/status_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: status.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `status.cpp` zawiera implementację metod klasy `status`, odpowiedzialnej za zarządzanie statusami eksponatów (np. "Nowy", "Używany", "Uszkodzony") w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie statusów w tabeli `statuses` w bazie danych MySQL, współpracując z interfejsem użytkownika (`QListView`, `QLineEdit`) oraz klasą `MainWindow` w celu odświeżania combo boxów statusów po zapisaniu zmian.

--- a/documentation/status_h.md
+++ b/documentation/status_h.md
@@ -4,7 +4,7 @@
 - **Plik**: status.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `status.h` definiuje klasę `status`, która reprezentuje okno dialogowe do zarządzania statusami eksponatów (np. "Nowy", "Używany", "Uszkodzony") w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie statusów w tabeli `statuses` w bazie danych oraz synchronizację z głównym oknem (`MainWindow`) w celu odświeżenia combo boxów statusów po zapisaniu zmian. Jest częścią systemu słownikowego aplikacji, podobnie jak klasy `models` czy `vendors`.

--- a/documentation/storage_cpp.md
+++ b/documentation/storage_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: storage.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `storage.cpp` zawiera implementację metod klasy `storage`, odpowiedzialnej za zarządzanie miejscami przechowywania eksponatów (np. magazyny, półki, pokoje) w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie lokalizacji w tabeli `storage_places` w bazie danych MySQL, współpracując z interfejsem użytkownika (`QListView`, `QLineEdit`) oraz klasą `MainWindow` w celu odświeżania combo boxów lokalizacji po zapisaniu zmian.

--- a/documentation/storage_h.md
+++ b/documentation/storage_h.md
@@ -4,7 +4,7 @@
 - **Plik**: storage.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `storage.h` definiuje klasę `storage`, która reprezentuje okno dialogowe do zarządzania miejscami przechowywania eksponatów (np. magazyny, półki, pokoje) w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie lokalizacji w tabeli `storage_places` w bazie danych oraz synchronizację z głównym oknem (`MainWindow`) w celu odświeżenia combo boxów lokalizacji po zapisaniu zmian. Jest częścią systemu słownikowego aplikacji, podobnie jak klasy `models`, `status` czy `vendors`.

--- a/documentation/types_cpp.md
+++ b/documentation/types_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: types.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `types.cpp` zawiera implementację metod klasy `types`, odpowiedzialnej za zarządzanie typami eksponatów (np. Komputer, Monitor, Drukarka) w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie typów w tabeli `types` w bazie danych MySQL, współpracując z interfejsem użytkownika (`QListView`, `QLineEdit`) oraz klasą `MainWindow` w celu odświeżania combo boxów typów po zapisaniu zmian.

--- a/documentation/types_h.md
+++ b/documentation/types_h.md
@@ -4,7 +4,7 @@
 - **Plik**: types.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `types.h` definiuje klasę `types`, która reprezentuje okno dialogowe do zarządzania typami eksponatów (np. Komputer, Monitor, Drukarka) w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie typów w tabeli `types` w bazie danych oraz synchronizację z głównym oknem (`MainWindow`) w celu odświeżenia combo boxów typów po zapisaniu zmian. Jest częścią systemu słownikowego aplikacji, podobnie jak klasy `models`, `status`, `storage` czy `vendors`.

--- a/documentation/utils_cpp.md
+++ b/documentation/utils_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: utils.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `utils.cpp` zawiera implementację funkcji `setupDatabase`, która konfiguruje i otwiera połączenie z bazą danych SQLite lub MySQL w aplikacji inwentaryzacyjnej. Funkcja rejestruje połączenie pod nazwą "default_connection", używaną przez inne komponenty aplikacji (np. `MainWindow`, `types`, `status`). Dla SQLite automatycznie tworzy schemat bazy danych (tabele i dane początkowe), co zapewnia gotowość bazy do pracy po pierwszym uruchomieniu.

--- a/documentation/utils_h.md
+++ b/documentation/utils_h.md
@@ -4,7 +4,7 @@
 - **Plik**: utils.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `utils.h` definiuje funkcję `setupDatabase`, która jest odpowiedzialna za inicjalizację połączenia z bazą danych w aplikacji inwentaryzacyjnej. Funkcja umożliwia konfigurację połączenia dla baz SQLite (lokalny plik) lub MySQL (zdalne połączenie), rejestrując je pod nazwą "default_connection". Jest to kluczowy komponent aplikacji, wykorzystywany na etapie uruchamiania, np. przez `DatabaseConfigDialog`, do przygotowania bazy danych dla innych komponentów, takich jak `MainWindow`, `types`, `status`, `storage` czy `models`.

--- a/documentation/vendors_cpp.md
+++ b/documentation/vendors_cpp.md
@@ -4,7 +4,7 @@
 - **Plik**: vendors.cpp
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `vendors.cpp` zawiera implementację metod klasy `vendors`, odpowiedzialnej za zarządzanie producentami sprzętu (np. Commodore, IBM, Apple) w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie producentów w tabeli `vendors` w bazie danych MySQL, współpracując z interfejsem użytkownika (`QListView`, `QLineEdit`) oraz klasą `MainWindow` w celu odświeżania combo boxów producentów po zapisaniu zmian.

--- a/documentation/vendors_h.md
+++ b/documentation/vendors_h.md
@@ -4,7 +4,7 @@
 - **Plik**: vendors.h
 - **Wersja**: 1.2.2
 - **Data**: 2025-05-03
-- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+- **Autorzy**: Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
 
 ## Przegląd
 Plik `vendors.h` definiuje klasę `vendors`, która reprezentuje okno dialogowe do zarządzania producentami sprzętu (np. Commodore, IBM, Apple) w aplikacji inwentaryzacyjnej. Klasa umożliwia dodawanie, edytowanie i usuwanie producentów w tabeli `vendors` w bazie danych oraz synchronizację z głównym oknem (`MainWindow`) w celu odświeżenia combo boxów producentów po zapisaniu zmian. Jest częścią systemu słownikowego aplikacji, podobnie jak klasy `models`, `status`, `storage` czy `types`.

--- a/include/DatabaseConfigDialog.h
+++ b/include/DatabaseConfigDialog.h
@@ -1,7 +1,7 @@
 /**
  * @file DatabaseConfigDialog.h
  * @brief Deklaracja klasy DatabaseConfigDialog do konfiguracji połączenia z bazą danych oraz wyboru skórki graficznej.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025- istituti-03
  *

--- a/include/ItemFilterProxyModel.h
+++ b/include/ItemFilterProxyModel.h
@@ -1,7 +1,7 @@
 /**
  * @file ItemFilterProxyModel.h
  * @brief Deklaracja klasy ItemFilterProxyModel do filtrowania listy eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/include/fullscreenphotoviewer.h
+++ b/include/fullscreenphotoviewer.h
@@ -1,7 +1,7 @@
 /**
  * @file fullscreenphotoviewer.h
  * @brief Deklaracja klas ZoomableGraphicsView i FullScreenPhotoViewer do pełnoekranowego podglądu zdjęć.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/include/itemList.h
+++ b/include/itemList.h
@@ -1,7 +1,7 @@
 /**
  * @file itemList.h
  * @brief Deklaracja klasy itemList, odpowiedzialnej za zarządzanie listą eksponatów w aplikacji inwentaryzacyjnej.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -1,7 +1,7 @@
 /**
  * @file mainwindow.h
  * @brief Deklaracja klasy MainWindow do zarządzania formularzem eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/include/models.h
+++ b/include/models.h
@@ -1,7 +1,7 @@
 /**
  * @file models.h
  * @brief Deklaracja klasy models do zarządzania modelami eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/include/photoitem.h
+++ b/include/photoitem.h
@@ -1,7 +1,7 @@
 /**
  * @file photoitem.h
  * @brief Deklaracja klasy PhotoItem reprezentującej interaktywny element graficzny zdjęcia.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/include/status.h
+++ b/include/status.h
@@ -3,7 +3,7 @@
  * @brief Deklaracja klasy status służącej do zarządzania statusami eksponatów w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera deklarację klasy status, która reprezentuje okno dialogowe do zarządzania

--- a/include/storage.h
+++ b/include/storage.h
@@ -3,7 +3,7 @@
  * @brief Deklaracja klasy storage służącej do zarządzania miejscami przechowywania eksponatów w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera deklarację klasy storage, która reprezentuje okno dialogowe do zarządzania

--- a/include/types.h
+++ b/include/types.h
@@ -3,7 +3,7 @@
  * @brief Deklaracja klasy types służącej do zarządzania typami eksponatów w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera deklarację klasy types, która reprezentuje okno dialogowe do zarządzania

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,7 +3,7 @@
  * @brief Deklaracja funkcji pomocniczych wykorzystywanych w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera deklarację funkcji `setupDatabase`, odpowiedzialnej za inicjalizację

--- a/include/vendors.h
+++ b/include/vendors.h
@@ -3,7 +3,7 @@
  * @brief Deklaracja klasy vendors do zarządzania producentami sprzętu w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera deklarację klasy vendors, która reprezentuje okno dialogowe do zarządzania

--- a/src/DatabaseConfigDialog.cpp
+++ b/src/DatabaseConfigDialog.cpp
@@ -1,7 +1,7 @@
 /**
  * @file DatabaseConfigDialog.cpp
  * @brief Implementacja klasy DatabaseConfigDialog z obsługą tworzenia nowego pliku SQLite oraz wyboru skórki graficznej aplikacji.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/ItemFilterProxyModel.cpp
+++ b/src/ItemFilterProxyModel.cpp
@@ -1,7 +1,7 @@
 /**
  * @file ItemFilterProxyModel.cpp
  * @brief Implementacja klasy ItemFilterProxyModel do filtrowania listy eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/fullscreenphotoviewer.cpp
+++ b/src/fullscreenphotoviewer.cpp
@@ -1,7 +1,7 @@
 /**
  * @file fullscreenphotoviewer.cpp
  * @brief Pusty plik implementacyjny dla klas ZoomableGraphicsView i FullScreenPhotoViewer.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/itemList.cpp
+++ b/src/itemList.cpp
@@ -1,7 +1,7 @@
 /**
  * @file itemList.cpp
  * @brief Implementacja klasy itemList do zarządzania listą eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *
@@ -941,7 +941,7 @@ void itemList::onAboutClicked()
                              .arg(QCoreApplication::applicationName(),
                                   QStringLiteral("Program do inwentaryzacji retro komputerów"),
                                   QStringLiteral(
-                                      "Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK"),
+                                      "Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK"),
                                   QCoreApplication::applicationVersion());
 
     QMessageBox::about(this, tr("O programie"), html);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 /**
  * @file main.cpp
  * @brief Główny punkt wejścia aplikacji inwentaryzacyjnej.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,7 +1,7 @@
 /**
  * @file mainwindow.cpp
  * @brief Implementacja klasy MainWindow do zarządzania formularzem eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/models.cpp
+++ b/src/models.cpp
@@ -1,7 +1,7 @@
 /**
  * @file models.cpp
  * @brief Implementacja klasy models do zarządzania modelami eksponatów.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/photoitem.cpp
+++ b/src/photoitem.cpp
@@ -1,7 +1,7 @@
 /**
  * @file photoitem.cpp
  * @brief Implementacja klasy PhotoItem, interaktywnego elementu graficznego dla zdjęć.
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  * @version \projectnumber
  * @date 2025-05-03
  *

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -3,7 +3,7 @@
  * @brief Implementacja klasy status do zarządzania statusami eksponatów w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera implementację metod klasy status, odpowiedzialnej za zarządzanie statusami

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -3,7 +3,7 @@
  * @brief Implementacja klasy storage służącej do zarządzania miejscami przechowywania eksponatów w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera implementację metod klasy storage, odpowiedzialnej za zarządzanie

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -3,7 +3,7 @@
  * @brief Implementacja klasy types do zarządzania typami eksponatów w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera implementację metod klasy types, odpowiedzialnej za zarządzanie

--- a/src/vendors.cpp
+++ b/src/vendors.cpp
@@ -3,7 +3,7 @@
  * @brief Implementacja klasy vendors do zarządzania producentami sprzętu w aplikacji inwentaryzacyjnej.
  * @version \projectnumber
  * @date 2025-05-03
- * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & ChatGPT & GROK
+ * @author Stowarzyszenie Miłośników Oldschoolowych Komputerów SMOK & Claude & ChatGPT & GROK
  *
  * @section Overview
  * Plik zawiera implementację metod klasy vendors, odpowiedzialnej za zarządzanie


### PR DESCRIPTION
## Cel — credits only do main

Arek poprosił o dopisanie Claude do wszystkich miejsc z creditami AI (ChatGPT, GROK). Claude dołączył ostatni ale dziś (2026-04-26) sporo pomógł — 4 release + 4 dokumenty projektowe.

**TYLKO opisowe** — bez kodu, bez bump wersji, bez tagu, bez release.

## Zmiany (1 commit po squash z PR #29)

- 49 plików `.h`/`.cpp` + `documentation/*.md`: doxygen `@author SMOK & ChatGPT & GROK` → `SMOK & Claude & ChatGPT & GROK`
- `README.md` — 4 wzmianki w narratywnym tekście
- `CHANGELOG.md` — 1 wzmianka
- `.gitignore` — re-fix `.claude/` + `build/`

## Po scaleniu
- ❌ NIE robimy taga `v*`
- ❌ NIE robimy release CI
- README na github.com pokaże nowe credits — to wystarczy