### PR TITLE
docs: zmiana licencji WTFPL → MIT (Yugorin)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,34 @@
-DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-Version 2, December 2004
+MIT License
 
-Copyright (C) 2025 Arek "Yugorin" Bronowicki, chatGPT, GROK
+Copyright (c) 2025-2026 Yugorin (Arek Bronowicki, GitHub: arekbr)
 
-Everyone is permitted to copy and distribute verbatim or modified copies of this license document, and changing it is allowed as long as the name is changed.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-0. You just DO WHAT THE FUCK YOU WANT TO.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ---
 
-Notatka: Kod źródłowy projektu Inwentaryzacja jest udostępniony na licencji WTFPL, co oznacza, że możesz z nim robić, co chcesz! Szczegóły powyżej.
+Third-party dependencies retain their own licenses:
+- Qt 6 (LGPL v3) — https://www.qt.io/licensing/
+- SQLite (Public Domain) — https://www.sqlite.org/copyright.html
+- MySQL/MariaDB Connector (GPL with FOSS Exception) — https://www.mysql.com/about/legal/licensing/foss-exception/
+- ZLIB (zlib License) — https://www.zlib.net/zlib_license.html
+- Anthropic SDK / Claude API access (commercial, payment-based) — https://www.anthropic.com/legal
+
+Note: This project previously used WTFPL (Do What The Fuck You Want Public License).
+Switched to MIT in 2026-04 for broader OSI-recognized acceptance and clarity.
+The license terms above (MIT) supersede any prior license notices.


### PR DESCRIPTION
## Cel
Arek (Yugorin) poprosił o MIT zamiast obecnego WTFPL.

## Zmiany — TYLKO LICENSE
- WTFPL → **MIT** (OSI-approved, praktycznie tak samo liberalna, broader acceptance)
- Copyright: `Yugorin (Arek Bronowicki, GitHub: arekbr)` — pseudonim Yugorin na pierwszym miejscu (AI nie powinno być copyright holderem, tylko creditem w README)
- Sekcja **Third-party dependencies** z listą zależności i ich licencji (Qt LGPL, SQLite Public Domain, MariaDB GPL+FOSS exception, ZLIB)
- Transparentna notatka o zmianie (dla forków sprzed kwietnia 2026)

## Bez release / tagu / bumpa wersji
Pure docs. Następny realny release v1.5.1+ scali to z resztą.

## Dlaczego MIT (nie WTFPL)
- WTFPL nie jest OSI-approved → niektóre korpo i niektóre platformy go nie uznają
- Nazwa "Do What The Fuck You Want" odstrasza w profesjonalnym kontekście
- MIT to standard de facto dla one-man-projektów open source

Wszystko inne identyczne (kompatybilna z Qt LGPL, każdy może używać/forkować/modyfikować/sprzedawać byle wzmianka o autorze).